### PR TITLE
Initial separation of the single h file into .c's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,3 +95,6 @@ if (NOT MSVC)
 endif()
 
 add_subdirectory(functional_tests)
+
+add_library(nanoarq STATIC src/arq.c)
+target_include_directories(nanoarq PUBLIC ${CMAKE_SOURCE_DIR})

--- a/arq.h
+++ b/arq.h
@@ -2,17 +2,22 @@
 #ifndef ARQ_H_INCLUDED
 #define ARQ_H_INCLUDED
 
+// TODO: Figure out a better system for compile time options
 #ifndef ARQ_USE_C_STDLIB
-    #error You must define ARQ_USE_C_STDLIB to 0 or 1 before including arq.h
+    #warning You must define ARQ_USE_C_STDLIB to 0 or 1 before including arq.h
+    #define ARQ_USE_C_STDLIB (1)
 #endif
 #ifndef ARQ_COMPILE_CRC32
-    #error You must define ARQ_COMPILE_CRC32 to 0 or 1 before including arq.h
+    #warning You must define ARQ_COMPILE_CRC32 to 0 or 1 before including arq.h
+    #define ARQ_COMPILE_CRC32 (1)
 #endif
 #ifndef ARQ_LITTLE_ENDIAN_CPU
-    #error You must define ARQ_LITTLE_ENDIAN_CPU to 0 or 1 before including arq.h
+    #warning You must define ARQ_LITTLE_ENDIAN_CPU to 0 or 1 before including arq.h
+    #define ARQ_LITTLE_ENDIAN_CPU (1)
 #endif
 #ifndef ARQ_USE_CONNECTIONS
-    #error You must define ARQ_USE_CONNECTIONS to 0 or 1 before including arq.h
+    #warning You must define ARQ_USE_CONNECTIONS to 0 or 1 before including arq.h
+    #define ARQ_USE_CONNECTIONS (1)
 #endif
 
 #if ARQ_USE_C_STDLIB == 1
@@ -522,30 +527,6 @@ arq_err_t arq_required_size(arq_cfg_t const *cfg, unsigned *out_required_size)
     arq__lin_alloc_init(&la, ARQ_NULL_PTR, (unsigned)-1);
     arq__alloc(cfg, &la);
     *out_required_size = la.size;
-    return ARQ_OK_COMPLETED;
-}
-
-arq_err_t arq_init(arq_cfg_t const *cfg, void *arq_seat, unsigned arq_seat_size, struct arq_t **out_arq)
-{
-    arq__lin_alloc_t la;
-    arq_err_t check_err;
-    arq_t *arq;
-    if (!cfg || !arq_seat || !out_arq) {
-        return ARQ_ERR_INVALID_PARAM;
-    }
-    check_err = arq__check_cfg(cfg);
-    if (!ARQ_SUCCEEDED(check_err)) {
-        return check_err;
-    }
-    arq__lin_alloc_init(&la, arq_seat, arq_seat_size);
-    arq = arq__alloc(cfg, &la);
-    if (!arq) {
-        return ARQ_ERR_INVALID_PARAM;
-    }
-    arq->cfg = *cfg;
-    arq__init(arq);
-    arq__rst(arq);
-    *out_arq = arq;
     return ARQ_OK_COMPLETED;
 }
 

--- a/compilation_tests/CMakeLists.txt
+++ b/compilation_tests/CMakeLists.txt
@@ -2,42 +2,50 @@ cmake_minimum_required(VERSION 3.4)
 project(compilation_tests C CXX)
 
 function(add_arq_lib TARGET_NAME TARGET_FLAGS TARGET_SOURCE)
-    add_library(${TARGET_NAME} STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME} STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME} nanoarq)
     target_compile_options(${TARGET_NAME} PRIVATE
                            -DARQ_ASSERTS_ENABLED=1 -DARQ_USE_C_STDLIB=1 -DARQ_USE_CONNECTIONS=1
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_asserts STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_asserts STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_asserts nanoarq)
     target_compile_options(${TARGET_NAME}_no_asserts PRIVATE
                            -DARQ_ASSERTS_ENABLED=0 -DARQ_USE_C_STDLIB=1 -DARQ_USE_CONNECTIONS=1
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_cstdlib STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_cstdlib STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_cstdlib nanoarq)
     target_compile_options(${TARGET_NAME}_no_cstdlib PRIVATE
                            -DARQ_ASSERTS_ENABLED=1 -DARQ_USE_C_STDLIB=0 -DARQ_USE_CONNECTIONS=1
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_asserts_no_cstdlib STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_asserts_no_cstdlib STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_asserts_no_cstdlib nanoarq)
     target_compile_options(${TARGET_NAME}_no_asserts_no_cstdlib PRIVATE
                            -DARQ_ASSERTS_ENABLED=0 -DARQ_USE_C_STDLIB=0 -DARQ_USE_CONNECTIONS=1
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_conn STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_conn STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_conn nanoarq)
     target_compile_options(${TARGET_NAME}_no_conn PRIVATE
                            -DARQ_ASSERTS_ENABLED=1 -DARQ_USE_C_STDLIB=1 -DARQ_USE_CONNECTIONS=0
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_asserts_no_conn STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_asserts_no_conn STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_asserts_no_conn nanoarq)
     target_compile_options(${TARGET_NAME}_no_asserts_no_conn PRIVATE
                            -DARQ_ASSERTS_ENABLED=0 -DARQ_USE_C_STDLIB=1 -DARQ_USE_CONNECTIONS=0
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_cstdlib_no_conn STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_cstdlib_no_conn STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_cstdlib_no_conn nanoarq)
     target_compile_options(${TARGET_NAME}_no_cstdlib_no_conn PRIVATE
                            -DARQ_ASSERTS_ENABLED=1 -DARQ_USE_C_STDLIB=0 -DARQ_USE_CONNECTIONS=0
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})
 
-    add_library(${TARGET_NAME}_no_asserts_no_cstdlib_no_conn STATIC ${CMAKE_SOURCE_DIR}/arq.h ${TARGET_SOURCE})
+    add_library(${TARGET_NAME}_no_asserts_no_cstdlib_no_conn STATIC ${TARGET_SOURCE})
+    target_link_libraries(${TARGET_NAME}_no_asserts_no_cstdlib_no_conn nanoarq)
     target_compile_options(${TARGET_NAME}_no_asserts_no_cstdlib_no_conn PRIVATE
                            -DARQ_ASSERTS_ENABLED=0 -DARQ_USE_C_STDLIB=0 -DARQ_USE_CONNECTIONS=0
                            ${ARQ_RUNTIME_FLAGS} ${ARQ_COMMON_FLAGS} ${TARGET_FLAGS})

--- a/functional_tests/CMakeLists.txt
+++ b/functional_tests/CMakeLists.txt
@@ -8,8 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 include_directories(${CPPUTEST_INCLUDE_DIR})
 
-set(ARQ_FUNCTIONAL_TEST_SOURCES ${CMAKE_SOURCE_DIR}/arq.h
-                                main.cpp
+set(ARQ_FUNCTIONAL_TEST_SOURCES main.cpp
                                 functional_tests.h
                                 arq_in_functional_tests.h
                                 arq_in_functional_tests.c
@@ -44,7 +43,7 @@ set_source_files_properties(arq_in_test_project.c PROPERTIES COMPILE_FLAGS "${AR
 add_executable(arq_functional_tests ${ARQ_FUNCTIONAL_TEST_SOURCES})
 target_compile_options(arq_functional_tests PRIVATE ${ARQ_COMMON_FLAGS})
 add_dependencies(arq_functional_tests CppUTest_external)
-target_link_libraries(arq_functional_tests libCppUTest libCppUTestExt)
+target_link_libraries(arq_functional_tests libCppUTest libCppUTestExt nanoarq)
 
 if (MSVC)
     target_link_libraries(arq_functional_tests winmm)

--- a/src/arq.c
+++ b/src/arq.c
@@ -1,0 +1,28 @@
+/* This code is in the public domain. See the LICENSE file for details. */
+
+#include "arq.h"
+
+arq_err_t arq_init(arq_cfg_t const *cfg, void *arq_seat, unsigned arq_seat_size, struct arq_t **out_arq)
+{
+    arq__lin_alloc_t la;
+    arq_err_t check_err;
+    arq_t *arq;
+    if (!cfg || !arq_seat || !out_arq) {
+        return ARQ_ERR_INVALID_PARAM;
+    }
+    check_err = arq__check_cfg(cfg);
+    if (!ARQ_SUCCEEDED(check_err)) {
+        return check_err;
+    }
+    arq__lin_alloc_init(&la, arq_seat, arq_seat_size);
+    arq = arq__alloc(cfg, &la);
+    if (!arq) {
+        return ARQ_ERR_INVALID_PARAM;
+    }
+    arq->cfg = *cfg;
+    arq__init(arq);
+    arq__rst(arq);
+    *out_arq = arq;
+    return ARQ_OK_COMPLETED;
+}
+

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -70,7 +70,7 @@ add_dependencies(arq_unit_test_objs CppUTest_external)
 
 ############# Arq runtime for unit tests
 
-set(ARQ_UNIT_TEST_SOURCES ${CMAKE_SOURCE_DIR}/arq.h arq_in_unit_tests.h arq_in_unit_tests.c)
+set(ARQ_UNIT_TEST_SOURCES  arq_in_unit_tests.h arq_in_unit_tests.c)
 string(REPLACE ";" " " ARQ_RUNTIME_FLAGS_STR "${ARQ_RUNTIME_FLAGS}")
 set_source_files_properties(arq_unit_test.c PROPERTIES COMPILE_FLAGS "${ARQ_RUNTIME_FLAGS_STR}")
 
@@ -80,7 +80,7 @@ add_executable(arq_unit_tests ${ARQ_UNIT_TEST_SOURCES} $<TARGET_OBJECTS:arq_unit
 add_dependencies(arq_unit_tests CppUTest_external)
 target_compile_options(arq_unit_tests PRIVATE
                        ${ARQ_COMMON_FLAGS} -DARQ_ASSERTS_ENABLED=1 -DARQ_USE_CONNECTIONS=1)
-target_link_libraries(arq_unit_tests arq_test_support libCppUTest libCppUTestExt)
+target_link_libraries(arq_unit_tests arq_test_support libCppUTest libCppUTestExt nanoarq)
 if(CMAKE_GENERATOR STREQUAL Xcode)
     target_link_libraries(arq_unit_tests c++)
 endif()
@@ -92,7 +92,7 @@ add_executable(arq_no_asserts_unit_tests ${ARQ_UNIT_TEST_SOURCES} $<TARGET_OBJEC
 add_dependencies(arq_no_asserts_unit_tests CppUTest_external)
 target_compile_options(arq_no_asserts_unit_tests PRIVATE
                        ${ARQ_COMMON_FLAGS} -DARQ_ASSERTS_ENABLED=0 -DARQ_USE_CONNECTIONS=1)
-target_link_libraries(arq_no_asserts_unit_tests arq_test_support libCppUTest libCppUTestExt)
+target_link_libraries(arq_no_asserts_unit_tests arq_test_support libCppUTest libCppUTestExt nanoarq)
 if(CMAKE_GENERATOR STREQUAL Xcode)
     target_link_libraries(arq_no_asserts_unit_tests c++)
 endif()


### PR DESCRIPTION
* Creates a static library to link against
* Moves arq_init into src/arq.c as a proof of concept
* Adds default options for previously required compile time flags